### PR TITLE
Resource Leak: Close SubRepos

### DIFF
--- a/git/changelog.go
+++ b/git/changelog.go
@@ -172,6 +172,8 @@ func (r *Repository) generateSubmoduleChangelog(commit *git.Commit) (map[string]
 		}
 
 		commits, err := subRepo.generateChangelog(subEntry.Id, parentSubEntry.Id)
+		subRepo.Close()
+
 		if err != nil {
 			r.Log.Println("Failed to generate submodule changelog:", err)
 			continue


### PR DESCRIPTION
I'm not a Go master but this might fix things.
This was the only resource leak I found in the repo.
The [link](https://github.com/SpongePowered/DownloadIndexer/blob/master/indexer/jar.go#L12) that @kashike posted actually _does_ close the files correctly (check the methods below it).